### PR TITLE
remove hack of relative interpreter

### DIFF
--- a/torzu-appimage.sh
+++ b/torzu-appimage.sh
@@ -110,7 +110,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B16 \
+	--compression zstd:level=22 -S23 -B16 \
 	--header uruntime \
 	-i ./AppDir -o Torzu-"$VERSION"-anylinux-"$ARCH".AppImage
 

--- a/torzu-appimage.sh
+++ b/torzu-appimage.sh
@@ -71,7 +71,7 @@ ln -s ./torzu.png ./.DirIcon
 # Bundle all libs
 wget --retry-connrefused --tries=30 "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
-xvfb-run -a -- ./lib4bin -p -v -r -e -s -k \
+xvfb-run -a -- ./lib4bin -p -v -e -s -k \
 	/usr/bin/yuzu* \
 	/usr/lib/libGLX* \
 	/usr/lib/libEGL* \

--- a/torzu-appimage.sh
+++ b/torzu-appimage.sh
@@ -90,18 +90,6 @@ xvfb-run -a -- ./lib4bin -p -v -r -e -s -k \
 	/usr/lib/pulseaudio/* \
 	/usr/lib/alsa-lib/*
 
-
-#########################################################################
-# For some wierd reason the yuzu binary is ignoring the --library-path given to the interpreter by sharun
-# IT SOMEHOW EVEN USES THE HOST INTERPRETER!
-
-# This is crazy that this is needed
-patchelf --set-interpreter './lib/ld-linux-x86-64.so.2' ./shared/bin/*
-echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}' > ./.env
-echo 'LD_LIBRARY_PATH=${SHARUN_DIR}/lib:${SHARUN_DIR}/lib/pulseaudio:${SHARUN_DIR}/lib/libproxy:${SHARUN_DIR}/lib/alsa-lib:${SHARUN_DIR}/lib/dri' >> ./.env
-
-#########################################################################
-
 # Prepare sharun
 ln ./sharun ./AppRun
 ./sharun -g


### PR DESCRIPTION
Turns out yuzu forks itself and uses `argv0` instead of `/proc/self/exe` to find itself, this caused it to bypass sharun all together and required a hack of setting a relative interpreter and also `$LD_LIBRARY_PATH`.

With https://github.com/VHSgunzo/sharun/commit/62a62d20e46482cf1ecdb0f85365df1deafa4447 this has been fixed, so the hack is no longer needed.