### PR TITLE
fix `StartupWMClass` to correct value

### DIFF
--- a/torzu-appimage.sh
+++ b/torzu-appimage.sh
@@ -58,7 +58,7 @@ Exec=yuzu %f
 Categories=Game;Emulator;Qt;
 MimeType=application/x-nx-nro;application/x-nx-nso;application/x-nx-nsp;application/x-nx-xci;
 Keywords=Nintendo;Switch;
-StartupWMClass=torzu' > ./torzu.desktop
+StartupWMClass=yuzu' > ./torzu.desktop
 
 if ! wget --retry-connrefused --tries=30 "$ICON" -O torzu.png; then
 	if ! wget --retry-connrefused --tries=30 "$ICON_BACKUP" -O torzu.png; then


### PR DESCRIPTION
Upstream has a .desktop file that contains [StartupWMClass=torzu](https://notabug.org/litucks/torzu/src/master/dist/onion.torzu_emu.torzu.desktop) but this is wrong, the class is still `yuzu` and as result this breaks pinning the .desktop to the bar in desktop enviroments, it also causes a wayland icon to show in the window decorations for wayland users. 

