### PR TITLE
add support for iGPUs from intel

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -64,16 +64,16 @@ pacman -Syu --noconfirm \
 
 
 case "$ARCH" in
-	'x86_64')  
+	'x86_64')
 		PKG_TYPE='x86_64.pkg.tar.zst'
-		pacman -Syu --noconfirm vulkan-intel haskell-gnutls svt-av1
+		pacman -Syu --noconfirm vulkan-intel intel-media-driver haskell-gnutls svt-av1
 		;;
-	'aarch64') 
+	'aarch64')
 		PKG_TYPE='aarch64.pkg.tar.xz'
 		pacman -Syu --noconfirm vulkan-freedreno vulkan-panfrost
 		;;
-	''|*)      
-		echo "Unknown cpu arch: $ARCH" 
+	''|*)
+		echo "Unknown cpu arch: $ARCH"
 		exit 1
 		;;
 esac

--- a/torzu-appimage.sh
+++ b/torzu-appimage.sh
@@ -94,6 +94,9 @@ rm -f ./sharun-aio
 ln ./sharun ./AppRun
 ./sharun -g
 
+# Make intel hardware accel work
+echo 'LIBVA_DRIVERS_PATH=${SHARUN_DIR}/shared/lib:${SHARUN_DIR}/shared/lib/dri' >> ./.env
+
 # turn appdir into appimage
 cd ..
 wget --retry-connrefused --tries=30 "$URUNTIME"      -O  ./uruntime


### PR DESCRIPTION
Fixes intel iGPU hardware accel support by adding intel-media-driver pkg and echoing the correct libva drivers path. also there were multiple extra spaces, removed it.